### PR TITLE
Fix links

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -18,8 +18,7 @@
     },
     "links": {
         "community": "https://discord.gg/QVKmbvBXA7",
-        "source": "https://github.com/hiimjasmine00/MoreIcons",
-        "homepage": "https://more-icons.hiimjasmine00.com"
+        "source": "https://github.com/hiimjasmine00/PlayerDataAPI"
     },
 	"tags": [
 		"content",


### PR DESCRIPTION
The links led to the More Icons API web page and GitHub page. I removed the "homepage" link, and updated the GitHub link to lead to the Player Data API GitHub. 