### PR TITLE
Update argon to 1.4.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 add_subdirectory($ENV{GEODE_SDK} ${CMAKE_CURRENT_BINARY_DIR}/geode)
 
-CPMAddPackage("gh:GlobedGD/argon@1.4.3")
+CPMAddPackage("gh:GlobedGD/argon@1.4.6")
 CPMAddPackage("gh:hiimjasmine00/jasmine-tools@1.5.1")
 target_link_libraries(${PROJECT_NAME} argon jasmine-tools)
 


### PR DESCRIPTION
Older versions of argon had bugs that can cause crashes or auth failures, mostly prominent on macOS but present on other platforms too